### PR TITLE
Validation failed

### DIFF
--- a/bin/git-pr-release
+++ b/bin/git-pr-release
@@ -194,7 +194,7 @@ def obtain_token!
 end
 
 def request_authorization(client, two_factor_code)
-  params = { :scopes => [ 'public_repo', 'repo' ], :note => 'git-pr-release' }
+  params = { :scopes => [ 'public_repo', 'repo' ], :note => "git-pr-release (#{Time.now})" }
   params[:headers] = { "X-GitHub-OTP" => two_factor_code} if two_factor_code
 
   auth = nil


### PR DESCRIPTION
``` sh
$ git-pr-release
Could not obtain GitHub API token.
Trying to generate token...
username? |reiji| reizist
password? (not saved) *****
/Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/octokit-2.7.2/lib/octokit/response/raise_error.rb:16:in `on_complete': POST https://api.github.com/authorizations: 422 - Validation Failed (Octokit::UnprocessableEntity)
Error summary:
  resource: OauthAccess
  code: already_exists
  field: description // See: https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/response.rb:9:in `block in call'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/response.rb:57:in `on_complete'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/response.rb:8:in `call'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/rack_builder.rb:139:in `build_response'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/connection.rb:377:in `run_request'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/faraday-0.9.1/lib/faraday/connection.rb:177:in `post'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/sawyer-0.5.5/lib/sawyer/agent.rb:94:in `call'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/octokit-2.7.2/lib/octokit/client.rb:257:in `request'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/octokit-2.7.2/lib/octokit/client.rb:138:in `post'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/octokit-2.7.2/lib/octokit/client/authorizations.rb:70:in `create_authorization'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/git-pr-release-0.1.2/bin/git-pr-release:202:in `request_authorization'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/git-pr-release-0.1.2/bin/git-pr-release:187:in `obtain_token!'
    from /Users/reiji/.rbenv/versions/2.2.0/lib/ruby/gems/2.2.0/gems/git-pr-release-0.1.2/bin/git-pr-release:256:in `<top (required)>'
    from /Users/reiji/.rbenv/versions/2.2.0/bin/git-pr-release:23:in `load'
    from /Users/reiji/.rbenv/versions/2.2.0/bin/git-pr-release:23:in `<main>'
```
- [Exception: Octokit::UnprocessableEntity](http://www.rubydoc.info/github/pengwynn/octokit/master/Octokit/UnprocessableEntity)
- [Github API v3 authorization for a specific app](https://developer.github.com/v3/oauth_authorizations/#get-or-create-an-authorization-for-a-specific-app)
